### PR TITLE
Fix Swagger gateway config

### DIFF
--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
         - id: user-service
           uri: http://localhost:8080
           predicates:
-            - Path=${app.api-prefix}/user/**
+            - Path=${app.api-prefix}/user-service/**
           filters:
             - StripPrefix=2
         - id: payment-service
@@ -61,21 +61,21 @@ springdoc:
   swagger-ui:
     urls:
       - name: user-service (via gateway)
-        url: /user/v3/api-docs
+        url: ${app.api-prefix}/user-service/v3/api-docs
       - name: payment-service (via gateway)
-        url: /payment/v3/api-docs
+        url: ${app.api-prefix}/payment/v3/api-docs
       - name: ticket-service (via gateway)
-        url: /ticket/v3/api-docs
+        url: ${app.api-prefix}/ticket/v3/api-docs
       - name: notification-service (via gateway)
-        url: /notification/v3/api-docs
+        url: ${app.api-prefix}/notification/v3/api-docs
       - name: route-service (via gateway)
-        url: /route/v3/api-docs
+        url: ${app.api-prefix}/route/v3/api-docs
       - name: content-service (via gateway)
-        url: /content/v3/api-docs
+        url: ${app.api-prefix}/content/v3/api-docs
       - name: order-service (via gateway)
-        url: /order/v3/api-docs
+        url: ${app.api-prefix}/order/v3/api-docs
       - name: scanner-service (via gateway)
-        url: /scanner/v3/api-docs
+        url: ${app.api-prefix}/scanner/v3/api-docs
 
       - name: user-service (direct 8080)
         url: http://localhost:8080/user/v3/api-docs

--- a/user-service/src/main/java/com/metro/user/configuration/OpenApiConfig.java
+++ b/user-service/src/main/java/com/metro/user/configuration/OpenApiConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
         info = @Info(title = "User Service API", version = "v1"),
-        servers = @Server(url = "/user-service") // phải trùng với path được route qua Gateway
+        servers = @Server(url = "/api/v1/user-service")
 )
 @Configuration
 public class OpenApiConfig {


### PR DESCRIPTION
## Summary
- update API gateway route for user-service
- add API prefix to Swagger URLs
- align user-service OpenAPI server url with gateway prefix

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac70a7b08320bef26273c5baf7d4