### PR TITLE
Fix Swagger gateway config

### DIFF
--- a/api-gateway/src/main/java/com/metro/api_gateway/configuration/AuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/metro/api_gateway/configuration/AuthenticationFilter.java
@@ -49,7 +49,7 @@ public class AuthenticationFilter implements GlobalFilter, Ordered {
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        if (isPublicEndpoint(exchange.getRequest(), "/user-service", publicUserServiceEndpoint)) {
+        if (isPublicEndpoint(exchange.getRequest(), "/user", publicUserServiceEndpoint)) {
             return chain.filter(exchange);
         } // Khi nào thêm service khác muốn một số public thì khai báo thêm
 

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -61,21 +61,21 @@ springdoc:
   swagger-ui:
     urls:
       - name: user-service (via gateway)
-        url: /user/v3/api-docs
+        url: ${app.api-prefix}/user/v3/api-docs
       - name: payment-service (via gateway)
-        url: /payment/v3/api-docs
+        url: ${app.api-prefix}/payment/v3/api-docs
       - name: ticket-service (via gateway)
-        url: /ticket/v3/api-docs
+        url: ${app.api-prefix}/ticket/v3/api-docs
       - name: notification-service (via gateway)
-        url: /notification/v3/api-docs
+        url: ${app.api-prefix}/notification/v3/api-docs
       - name: route-service (via gateway)
-        url: /route/v3/api-docs
+        url: ${app.api-prefix}/route/v3/api-docs
       - name: content-service (via gateway)
-        url: /content/v3/api-docs
+        url: ${app.api-prefix}/content/v3/api-docs
       - name: order-service (via gateway)
-        url: /order/v3/api-docs
+        url: ${app.api-prefix}/order/v3/api-docs
       - name: scanner-service (via gateway)
-        url: /scanner/v3/api-docs
+        url: ${app.api-prefix}/scanner/v3/api-docs
 
       - name: user-service (direct 8080)
         url: http://localhost:8080/user/v3/api-docs

--- a/user-service/src/main/java/com/metro/user/configuration/OpenApiConfig.java
+++ b/user-service/src/main/java/com/metro/user/configuration/OpenApiConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
         info = @Info(title = "User Service API", version = "v1"),
-        servers = @Server(url = "/user-service") // phải trùng với path được route qua Gateway
+        servers = @Server(url = "/api/v1/user")
 )
 @Configuration
 public class OpenApiConfig {

--- a/user-service/src/main/resources/application.yaml
+++ b/user-service/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 server:
   port: 8080
   servlet:
-    context-path: /user-service
+    context-path: /user
 spring:
   application:
     name: user-service


### PR DESCRIPTION
## Summary
- update API gateway route for user-service
- add API prefix to Swagger URLs
- align user-service OpenAPI server url with gateway prefix
- set user-service context path to `/user`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac70a7b08320bef26273c5baf7d4