### PR TITLE
Add OpenAPI configs to services

### DIFF
--- a/content-service/src/main/java/com/metro/content/configuration/OpenApiConfig.java
+++ b/content-service/src/main/java/com/metro/content/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.content.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Content Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/content-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )

--- a/notification-service/src/main/java/com/metro/notification/configuration/OpenApiConfig.java
+++ b/notification-service/src/main/java/com/metro/notification/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.notification.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Notification Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/notification-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )

--- a/order-service/src/main/java/com/metro/order/configuration/OpenApiConfig.java
+++ b/order-service/src/main/java/com/metro/order/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.order.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Order Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/order-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )

--- a/payment-service/src/main/java/com/metro/payment/configuration/OpenApiConfig.java
+++ b/payment-service/src/main/java/com/metro/payment/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.payment.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Payment Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/payment-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )

--- a/route-service/src/main/java/com/metro/route/configuration/OpenApiConfig.java
+++ b/route-service/src/main/java/com/metro/route/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.route.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Route Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/route-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )

--- a/scanner-service/src/main/java/com/metro/scanner/configuration/OpenApiConfig.java
+++ b/scanner-service/src/main/java/com/metro/scanner/configuration/OpenApiConfig.java
@@ -1,4 +1,4 @@
-package com.metro.ticket.configuration;
+package com.metro.scanner.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -6,10 +6,10 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "Ticket Service API", version = "v1"),
+        info = @Info(title = "Scanner Service API", version = "v1"),
         servers = {
                 @Server(url = "/api/v1/", description = "Via API Gateway"),
-                @Server(url = "/api/v1/ticket-service", description = "For health check"),
+                @Server(url = "/api/v1/scanner-service", description = "For health check"),
                 @Server(url = "/", description = "Direct"),
         }
 )


### PR DESCRIPTION
## Summary
- add OpenApiConfig to all services
- sync ticket-service OpenAPI configuration with others

## Testing
- `mvn -f payment-service/pom.xml -q -DskipTests package` *(fails: Could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68431ae11b10832094da46066000069c