### PR TITLE
[BE-0016] Fix Dockerfile entrypoint syntax

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -40,10 +40,4 @@ COPY target/api-gateway-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8888
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC",  
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/content-service/Dockerfile
+++ b/content-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/content-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8085
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/notification-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8083
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/order-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8086
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/payment-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8081
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/route-service/Dockerfile
+++ b/route-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/route-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8084
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/scanner-service/Dockerfile
+++ b/scanner-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/scanner-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8087
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/ticket-service/Dockerfile
+++ b/ticket-service/Dockerfile
@@ -40,10 +40,4 @@ COPY target/ticket-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8082
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -41,10 +41,4 @@ COPY target/user-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 
 # Thiết lập entrypoint với tối ưu JVM và các cấu hình Spring AOP
-ENTRYPOINT ["java", \
-    "-Xms128m", \
-    "-Xmx256m", \
-    "-XX:+UseSerialGC", 
-    "-Dspring.aop.proxy-target-class=true", \
-    "-Dspring.aop.auto=true", \
-    "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-XX:+UseSerialGC", "-Dspring.aop.proxy-target-class=true", "-Dspring.aop.auto=true", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## Summary
- correct Dockerfile ENTRYPOINT commands for all services

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684431942c808320844db7e4de03de27