### PR TITLE
Add AGENTS rule for fixbug branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Contribution Rules
+
+1. Use Git branches named `feature/<ticket>` when implementing new features. Example for ticket **[BE-0026] CRUD User**:
+   ```
+   git checkout -b feature/BE-0026
+   ```
+   For bug fixes, name the branch `fixbug/<ticket>`. Example:
+   ```
+   git checkout -b fixbug/BE-0016
+   ```
+2. The pull request title must include the ticket code and description. Example:
+   ```
+   [BE-0026] CRUD User
+   ```


### PR DESCRIPTION
## Summary
- clarify branch naming in AGENTS for feature and fixbug tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684add912f9c8320a23f1035ca4ff21a