### PR TITLE
[BE-0043] Fix CORS for Swagger

### DIFF
--- a/api-gateway/src/main/java/com/metro/api_gateway/configuration/CorsConfig.java
+++ b/api-gateway/src/main/java/com/metro/api_gateway/configuration/CorsConfig.java
@@ -12,8 +12,7 @@ public class CorsConfig {
     @Bean
     public CorsWebFilter corsWebFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOrigin("https://metro.anhtudev.works");
+        config.addAllowedOrigin("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setAllowCredentials(false); // hoặc true nếu dùng cookie


### PR DESCRIPTION
## Summary
- allow all origins through CORS in API Gateway so Swagger UI loads without 403

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because of no network access)*

------
https://chatgpt.com/codex/tasks/task_e_684af4e87cb08320b93ff5747ed75170