### PR TITLE
[BE-0044] Fix missing id in get role api response

### DIFF
--- a/user-service/src/main/java/com/metro/user/dto/response/role/RoleResponse.java
+++ b/user-service/src/main/java/com/metro/user/dto/response/role/RoleResponse.java
@@ -11,6 +11,7 @@ import lombok.experimental.FieldDefaults;
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class RoleResponse {
+    Long id;
     String name;
     String description;
     List<PermissionResponse> permissions;


### PR DESCRIPTION
## Summary
- include `id` property in RoleResponse so GET /roles returns each role ID

## Testing
- `./mvnw -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684af60ee2888320867d61d5a2a24067