### PR TITLE
[BE-0064] Fix bug 500 update user

### DIFF
--- a/user-service/src/main/java/com/metro/user/Exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/metro/user/Exception/GlobalExceptionHandler.java
@@ -30,7 +30,7 @@ public class GlobalExceptionHandler {
         apiResponse.setCode(ErrorCode.UNCATEGORIZED_EXCEPTION.getCode());
         apiResponse.setMessage(ErrorCode.UNCATEGORIZED_EXCEPTION.getMessage());
 
-        return ResponseEntity.badRequest().body(apiResponse);
+        return ResponseEntity.status(ErrorCode.UNCATEGORIZED_EXCEPTION.getStatusCode()).body(apiResponse);
     }
 
     @ExceptionHandler(value = AppException.class)

--- a/user-service/src/main/java/com/metro/user/service/impl/UserServiceImpl.java
+++ b/user-service/src/main/java/com/metro/user/service/impl/UserServiceImpl.java
@@ -27,6 +27,7 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -73,14 +74,14 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTED));
 
-        if (request.getUsername() != null && !user.getUsername().equals(request.getUsername())) {
+        if (request.getUsername() != null && !Objects.equals(user.getUsername(), request.getUsername())) {
             var existingUser = userRepository.findByUsername(request.getUsername());
             if (existingUser.isPresent() && !existingUser.get().getId().equals(user.getId())) {
                 throw new AppException(ErrorCode.USER_EXISTED);
             }
         }
 
-        if (request.getEmail() != null && !user.getEmail().equals(request.getEmail())) {
+        if (request.getEmail() != null && !Objects.equals(user.getEmail(), request.getEmail())) {
             var existingUser = userRepository.findByEmail(request.getEmail());
             if (existingUser.isPresent() && !existingUser.get().getId().equals(user.getId())) {
                 throw new AppException(ErrorCode.EMAIL_EXISTED);


### PR DESCRIPTION
## Summary
- avoid NPE when user email or username are null when updating user
- return HTTP 500 for uncategorized exceptions

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685cc4802b148320b24d7acd21d45b35